### PR TITLE
Resolve unexpected manifest attribute error

### DIFF
--- a/deps-draw-graph/src/main/clojure/com/connexta/osgeyes/files/manifest.clj
+++ b/deps-draw-graph/src/main/clojure/com/connexta/osgeyes/files/manifest.clj
@@ -62,6 +62,7 @@
         ::Require-Capability
         ::Tool
         ::Service-Version
+        ::Service-Component
         ::Karaf-Commands
         ::Web-ContextPath
         ::Webapp-Context


### PR DESCRIPTION
Add `::Service-Component` to `manifest.clj` to fix an unexpected manifest attribute error.